### PR TITLE
got photo uploader working by commenting out some conflicting methods…

### DIFF
--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -8,14 +8,14 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  # storage :file
   # storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
-  def store_dir
-    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
+  # def store_dir
+  #   "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  # end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url


### PR DESCRIPTION
… in photo_uploader.rb

comment out storage :file and the store_dir method, which are not needed when using Cloudinary's plugin for CarrierWave.